### PR TITLE
Fix "warning: 'delete' applied to a pointer that was allocated with '…

### DIFF
--- a/src/ProteinDomains.cpp
+++ b/src/ProteinDomains.cpp
@@ -511,8 +511,8 @@ void ProteinDomains::MutualInformation(MultiAlignRec* pssmAlignment, Motif* alig
 		delete MIConf[i];
 	delete Minfo;
 	delete MIConf;
-	delete ttl_acids;
-	delete obs_acids;
+	delete [] ttl_acids;
+	delete [] obs_acids;
 	delete posPref;
 }
 


### PR DESCRIPTION
…new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]".

Fix "warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]".